### PR TITLE
Modif marqueur

### DIFF
--- a/localiserparcelle/localise.py
+++ b/localiserparcelle/localise.py
@@ -103,7 +103,7 @@ class plugin(QObject):
 		iface.deregisterLocatorFilter(self.locator_filter)
 		self.locator_filter = None
 
-	def close_Event(self, event): self.cleanMarker()
+	#def close_Event(self, event): self.cleanMarker()
 
 
 	def run(self):
@@ -122,7 +122,7 @@ class plugin(QObject):
 		self.dlg.setGeometry(win.geometry().x()+50,win.geometry().y()+50,200,200) #"""
 		
 		# fermeture de la fenetre du plugin on deroute sur une fonction interne
-		self.dlg.closeEvent = self.close_Event
+		#self.dlg.closeEvent = self.close_Event
 		########################
 		#INSERTION DES SIGNAUX #
 		########################
@@ -200,7 +200,7 @@ class plugin(QObject):
 		self.marker = None
 		self.tempGeometry = []
 
-	def closeDlg(self): self.dlg.reject(); self.cleanMarker(); 
+	def closeDlg(self): self.dlg.reject(); #self.cleanMarker(); 
 
 	def getListDepartements(self, index=0):
 		self.getListAction(1,False)

--- a/localiserparcelle/metadata.txt
+++ b/localiserparcelle/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Localiser Parcelle Adresse (BAN)
-version=3.5.1
+version=3.5.2
 qgisMinimumVersion=3.0
 
 description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : communes, parcelles cadastrales ou adresse
@@ -8,6 +8,7 @@ description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : co
 about= Cette extension exploite (par le protocole <b>http</b>):<br><ol><li>le service Web du Ministère de la Transition Ecologique et Solidaire de géolocalisation avec plusieurs échelles administratives (Région, Département, Commune, Section, Parcelle) ;</li><li>le service web de géolocalisation à l'adresse Etalab.gouv.fr-BAN.</li></ol>Ces deux web services fonctionnent depuis des postes de travail ayant un accès internet, en utilisant la configuration réseau de qgis pour le protocole HTTP et le système de projection courant du projet pour toute transformation des coordonnées.<br><br>
 
 changelog=
+ 3.5.2 : le marqueur reste affiché lorsqu'on ferme la fenêtre Localiser
  3.5.1 : corrige un bug
  3.5.0 : réduit le nombre de requêtes réseau en enregistrant sur le disque régions, départements et communes
  3.4.2 : vérifie à chaque ouverture de l'outil si la liste des régions est bien chargée pour le faire si besoin

--- a/localiserparcelle/ui_localise.py
+++ b/localiserparcelle/ui_localise.py
@@ -279,7 +279,7 @@ class Ui_Dialog(object):
 		self.ladrin.setText(_translate("Dialog", "N° et /ou voie :", None))
 		self.infracommune.setTabText(self.infracommune.indexOf(self.adresse), _translate("Dialog", "Adresse", None))
 		self.bErase.setText(_translate("Dialog", "Effacer", None))
-		self.bQuit.setText(_translate("Dialog", "Fermer", None))
+		self.bQuit.setText(_translate("Dialog", "Masquer", None))
 		self.bZoom.setText(_translate("Dialog", "Localiser", None))
 		self.optionGroupBox.setTitle("%s :" % _translate("Dialog", "Options du marqueur", None))
 		self.lblScale.setText("%s :" % _translate("Dialog", "Zoom élément trouvé  (m)", None))

--- a/localiserparcelle/ui_localise.py
+++ b/localiserparcelle/ui_localise.py
@@ -53,7 +53,7 @@ class Ui_Dialog(object):
 		self.gridLayout_2.addWidget(self.lRegion, 0, 1, 1, 3)
 		# 
 		self.bMajReg = QPushButton(QgsApplication.getThemeIcon('/mActionRefresh.svg'),'') #'Rafraichir')
-		self.bMajReg.setToolTip("Mettre à jour la liste des régions par le web")
+		self.bMajReg.setToolTip("Mettre à jour la liste des régions")
 		self.bMajReg.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 		self.gridLayout_2.addWidget(self.bMajReg, 0, 4, 1, 1)
 		
@@ -66,7 +66,7 @@ class Ui_Dialog(object):
 		self.gridLayout_2.addWidget(self.lDepartement, 1, 1, 1, 3)
 		# 
 		self.bMajDep = QPushButton(QgsApplication.getThemeIcon('/mActionRefresh.svg'),'')
-		self.bMajDep.setToolTip("Mettre à jour la liste des départements par le web")
+		self.bMajDep.setToolTip("Mettre à jour la liste des départements")
 		self.bMajDep.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 		self.gridLayout_2.addWidget(self.bMajDep, 1, 4, 1, 1)
 		
@@ -80,7 +80,7 @@ class Ui_Dialog(object):
 		self.gridLayout_2.addWidget(self.lCommune, 2, 1, 1, 3)
 		# 
 		self.bMajCom = QPushButton(QgsApplication.getThemeIcon('/mActionRefresh.svg'),'')
-		self.bMajCom.setToolTip("Mettre à jour la liste des communes par le web")
+		self.bMajCom.setToolTip("Mettre à jour la liste des communes")
 		self.bMajCom.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
 		self.gridLayout_2.addWidget(self.bMajCom, 2, 4, 1, 1)
 		
@@ -279,12 +279,12 @@ class Ui_Dialog(object):
 		self.ladrin.setText(_translate("Dialog", "N° et /ou voie :", None))
 		self.infracommune.setTabText(self.infracommune.indexOf(self.adresse), _translate("Dialog", "Adresse", None))
 		self.bErase.setText(_translate("Dialog", "Effacer", None))
-		self.bQuit.setText(_translate("Dialog", "Quitter", None))
+		self.bQuit.setText(_translate("Dialog", "Fermer", None))
 		self.bZoom.setText(_translate("Dialog", "Localiser", None))
 		self.optionGroupBox.setTitle("%s :" % _translate("Dialog", "Options du marqueur", None))
 		self.lblScale.setText("%s :" % _translate("Dialog", "Zoom élément trouvé  (m)", None))
 		self.lblColorOpacity.setText("%s :" % _translate("Dialog", "Couleur et opacité", None))
-		self.dynaMarker.setText(_translate("Dialog", "Dynamique", None))
+		self.dynaMarker.setText(_translate("Dialog", "Marqueur animé", None))
 
 
 


### PR DESCRIPTION
Pour répondre à une demande d'utilisateurs : que le marqueur reste visible, même quand on ferme la fenêtre Localiser.

Je propose aussi de changer les étiquettes suivantes :  
-- "Dynamique" : remplacé par "Marqueur animé" pour plus de clarté  
-- "Quitter" : remplacé par "Fermer" car la fenêtre Localiser est juste masquée, sans perdre la recherche en cours  