### PR TITLE
Numeros de parcelles plus simples

### DIFF
--- a/localiserparcelle/metadata.txt
+++ b/localiserparcelle/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Localiser Parcelle Adresse (BAN)
-version=3.5.2
+version=3.5.3
 qgisMinimumVersion=3.0
 
 description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : communes, parcelles cadastrales ou adresse
@@ -8,6 +8,7 @@ description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : co
 about= Cette extension exploite (par le protocole <b>http</b>):<br><ol><li>le service Web du Ministère de la Transition Ecologique et Solidaire de géolocalisation avec plusieurs échelles administratives (Région, Département, Commune, Section, Parcelle) ;</li><li>le service web de géolocalisation à l'adresse Etalab.gouv.fr-BAN.</li></ol>Ces deux web services fonctionnent depuis des postes de travail ayant un accès internet, en utilisant la configuration réseau de qgis pour le protocole HTTP et le système de projection courant du projet pour toute transformation des coordonnées.<br><br>
 
 changelog=
+ 3.5.3 : meilleure recherche des numéros de parcelles (sans les 0 au début du num.)
  3.5.2 : le marqueur reste affiché lorsqu'on ferme la fenêtre Localiser
  3.5.1 : corrige un bug
  3.5.0 : réduit le nombre de requêtes réseau en enregistrant sur le disque régions, départements et communes

--- a/localiserparcelle/ui_localise.py
+++ b/localiserparcelle/ui_localise.py
@@ -108,7 +108,7 @@ class Ui_Dialog(object):
 		self.lSection.setInsertPolicy(QComboBox.NoInsert)
 		self.lSection.lineEdit().setPlaceholderText("Choisir la section")
 		
-		self.lParcelle = QComboBox(self.parcelle) #filteredComboBox(self.parcelle) #
+		self.lParcelle = filteredComboBox(self.parcelle) # QComboBox(self.parcelle) # 
 		self.lParcelle.setEditable(True)
 		self.lParcelle.setInsertPolicy(QComboBox.NoInsert)
 		self.lParcelle.lineEdit().setPlaceholderText("Choisir la parcelle")


### PR DESCRIPTION
Les numéros de parcelles sont dorénavant affichés sans commencer par "00".
La saisie d'un numéro dans le combobox est facilitée, avec une recherche auto dans la liste.
Si on entre un numéro qui n'est pas dans la liste, la zone de saisie se colore en rouge.