### PR TITLE
corrige un bug avec la barre de recherche de QGIS

### DIFF
--- a/localiserparcelle/ban_locator_filter.py
+++ b/localiserparcelle/ban_locator_filter.py
@@ -56,7 +56,7 @@ class BanLocatorFilter(QgsLocatorFilter):
 
 	def triggerResult(self, result):
 		(score, type_info, x, y) = result.userData
-		print("{} {}".format(str(x), str(y)))
+		#print(x, y) #print("{} {}".format(str(x), str(y)))
 		transformer = self.plugin.getTransformer(4326)
 		point = transformer.transform( QgsPointXY(x,y), QgsCoordinateTransform.ForwardTransform)
 		x, y = point[0], point[1]

--- a/localiserparcelle/metadata.txt
+++ b/localiserparcelle/metadata.txt
@@ -1,6 +1,6 @@
 [general]
 name=Localiser Parcelle Adresse (BAN)
-version=3.5.3
+version=3.5.4
 qgisMinimumVersion=3.0
 
 description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : communes, parcelles cadastrales ou adresse
@@ -8,6 +8,7 @@ description= Localiser Parcelle Adresse (BAN) permet de localiser des lieux : co
 about= Cette extension exploite (par le protocole <b>http</b>):<br><ol><li>le service Web du Ministère de la Transition Ecologique et Solidaire de géolocalisation avec plusieurs échelles administratives (Région, Département, Commune, Section, Parcelle) ;</li><li>le service web de géolocalisation à l'adresse Etalab.gouv.fr-BAN.</li></ol>Ces deux web services fonctionnent depuis des postes de travail ayant un accès internet, en utilisant la configuration réseau de qgis pour le protocole HTTP et le système de projection courant du projet pour toute transformation des coordonnées.<br><br>
 
 changelog=
+ 3.5.4 : corrige un bug avec la barre de recherche de QGIS
  3.5.3 : meilleure recherche des numéros de parcelles (sans les 0 au début du num.)
  3.5.2 : le marqueur reste affiché lorsqu'on ferme la fenêtre Localiser
  3.5.1 : corrige un bug


### PR DESCRIPTION
La recherche "ban" dans la barre de recherche de QGIS fait appel à "zoomTo". Même si le dialog Localiser Parcelle Adresse n'a jamais été ouvert. Or zoomTo faisait appel à self.dlg.scale et self.dlg.dynaMarker.
Ce correctif remplace les "self.dlg..." par 2 variables : self.scaleZoom et self.marqueurDyna. Elles sont initialisée dans initGui.
Ces variables seront modifiées par self.dlg.scale.valueChanged et self.dlg.dynaMarker.clicked